### PR TITLE
Fixed ATtiny861 pinout

### DIFF
--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -20,41 +20,41 @@ ATTINY861 Pinout
      AVR Func         X16 Func   ArdIO   Port             Port   ArdIO   X16 Func    AVR Function
                                               ----\_/----
                                              | *         |
- (SPI MOSI) (SDA)      I2C_SDA     9     PB0 | 1       20| PA0     0     RESB
- (SPI MISO)            ACT_LED     8     PB1 | 2   A   19| PA1     1     NMIB
-  (SPI SCK) (SCL)      I2C_SCL     7     PB2 | 3   T   18| PA2     2     RESET_BTN
-                   PS2_KBD_DAT     6     PB3 | 4   t   17| PA3    14     NMI_BTN
+ (SPI MOSI) (SDA)      I2C_SDA     8     PB0 | 1       20| PA0     0     RESB
+ (SPI MISO)            ACT_LED     9     PB1 | 2   A   19| PA1     1     NMIB
+  (SPI SCK) (SCL)      I2C_SCL    10     PB2 | 3   T   18| PA2     2     RESET_BTN
+                   PS2_KBD_DAT    11     PB3 | 4   t   17| PA3     3     NMI_BTN
                                          VCC | 5   i   16| AGND
                                          GND | 6   n   15| AVCC
-                   PS2_KBD_CLK     5     PB4 | 7   y   14| PA4    10     POWER_BTN
-                   PS2_MSE_DAT     4     PB5 | 8   8   13| PA5    11     POWER_ON
-                   PS2_MSE_CLK     3     PB6 | 9   6   12| PA6    12     POWER_OK       (TXD)
-  (SPI SS) (RST)                  15     PB7 |10   1   11| PA7    13     IRQB           (RXD)
+                   PS2_KBD_CLK    12     PB4 | 7   y   14| PA4     4     POWER_BTN
+                   PS2_MSE_DAT    13     PB5 | 8   8   13| PA5     5     POWER_ON
+                   PS2_MSE_CLK    14     PB6 | 9   6   12| PA6     6     POWER_OK       (TXD)
+  (SPI SS) (RST)                  15     PB7 |10   1   11| PA7     7     IRQB           (RXD)
                                              |           |
                                               -----------
  */
 
 
-#define I2C_SDA_PIN       9
-#define I2C_SCL_PIN       7
+#define I2C_SDA_PIN        8
+#define I2C_SCL_PIN       10
 
-#define PS2_KBD_CLK       5
-#define PS2_KBD_DAT       6
-#define PS2_MSE_CLK       3
-#define PS2_MSE_DAT       4
+#define PS2_KBD_CLK       12
+#define PS2_KBD_DAT       11
+#define PS2_MSE_CLK       14
+#define PS2_MSE_DAT       13
 
-#define NMI_BUTTON_PIN    14
-#define RESET_BUTTON_PIN  2
-#define POWER_BUTTON_PIN  10
+#define NMI_BUTTON_PIN     3
+#define RESET_BUTTON_PIN   2
+#define POWER_BUTTON_PIN   4
 
 #define RESB_PIN          0
 #define NMIB_PIN          1
-#define IRQB_PIN          13
+#define IRQB_PIN          7
 
-#define PWR_ON            11
-#define PWR_OK            12
+#define PWR_ON            5
+#define PWR_OK            6
 
-#define ACT_LED           8
+#define ACT_LED           9
 
 #else
 
@@ -63,8 +63,8 @@ ATTINY861 Pinout
 #error "X16 SMC only builds for ATtiny861 and ATmega328P"
 #endif
 
-#ifdef  DEBUG
-#define   USE_SERIAL_DEBUG
+#if defined(DEBUG)
+#define USE_SERIAL_DEBUG
 #endif
 
 // Button definitions


### PR DESCRIPTION
The ATtiny861's logical to physical IO pin mapping differs from what is documented. Every pin was tested in isolation to establish this pinout map. After this change, the function of the power button was tested and correctly booted hardware from a cold start.