### PR TITLE
Build firmware with PlatformIO, enable CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: PlatformIO CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run
+      - name: Archive firmwares results
+        uses: actions/upload-artifact@v3
+        with:
+          name: SMC Firmwares
+          path: .pio/build/firmware*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: SMC Firmwares
-          path: .pio/build/firmware*
+          path: .pio/build/**/firmware.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,42 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+include_dir = .
+
+[env]
+; common settings
+platform = atmelavr@4.0.0
+framework = arduino
+; libraries common to all
+lib_deps =
+    mathertel/OneButton@2.0.3
+; exclude source files in the tests folder meant for cx16
+build_src_filter = +<*> -<tests/*>
+
+[env:uno]
+board = uno
+
+[env:uno_debug]
+extends = env:uno
+build_flags = -DUSE_SERIAL_DEBUG
+
+[env:attiny861]
+board = attiny861
+; as visible in the pinout code (D2 and D14 being used for interrupts), this uses the 2.0.0 preview
+; not the stable 1.5.2 core.
+; feed in the appropriate package.
+platform_packages =
+   framework-arduino-avr-attiny@https://github.com/maxgerhardt/ATTinyCore/archive/refs/heads/master.zip
+
+[env:attiny861_debug]
+extends = env:attiny861
+build_flags = -DUSE_SERIAL_DEBUG

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,14 +29,34 @@ board = uno
 extends = env:uno
 build_flags = -DUSE_SERIAL_DEBUG
 
+[env:uno_nmi_button]
+extends = env:uno
+build_flags = -DENABLE_NMI_BUT
+
 [env:attiny861]
 board = attiny861
 ; as visible in the pinout code (D2 and D14 being used for interrupts), this uses the 2.0.0 preview
 ; not the stable 1.5.2 core.
-; feed in the appropriate package.
+; feed in the appropriate package from the trusted registry.
 platform_packages =
-   framework-arduino-avr-attiny@https://github.com/maxgerhardt/ATTinyCore/archive/refs/heads/master.zip
+   maxgerhardt/framework-arduino-avr-attiny@2.0.0-dev
+; if you want to upload the firmware to the ATTiny via PlatformIO, select programmer here
+; in accordance to https://docs.platformio.org/en/latest/platforms/atmelavr.html#upload-using-programmer
+; example is for USBtinyISP.
+upload_protocol = custom
+upload_flags =
+    -C
+    ${platformio.packages_dir}/tool-avrdude/avrdude.conf
+    -p
+    $BOARD_MCU
+    -c
+    usbtiny
+upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i 
 
 [env:attiny861_debug]
 extends = env:attiny861
 build_flags = -DUSE_SERIAL_DEBUG
+
+[env:attiny861_nmi_button]
+extends = env:attiny861
+build_flags = -DENABLE_NMI_BUT


### PR DESCRIPTION
To make SMC firmware builds reproducable so that not only the original author can compile it with their computer, I added [PlatformIO](https://docs.platformio.org/en/latest/integration/ide/pioide.html) configuration file (`platformio.ini`) to the project. 

It enables the firmware code to be built for the Uno (ATmega328P) and ATTiny861 using [ATTinyCore 2.0.0-dev](https://github.com/SpenceKonde/ATTinyCore) with debugging enabled and disabled (`USE_SERIAL_DEBUG`) and the NMI button enabled or disabled (`ENABLE_NMI_BUT`).

It also enables Github Actions to build the firmware and archive the results (all `.elf` and `.hex` files).

Not tested on real hardware because I have none.

Sources the ATTiny 2.0.0-dev package from the PlatformIO trusted registry. 

Example CI run: [see here](https://github.com/maxgerhardt/x16-smc/actions/workflows/build.yml).

![grafik](https://user-images.githubusercontent.com/26485477/199985799-6aef6cef-b91b-4241-beb4-3fcb86feaee4.png)
